### PR TITLE
Remove reference to setPreserveJsDocWhitespace

### DIFF
--- a/src/java/com/github/jsdossier/CompilerModule.java
+++ b/src/java/com/github/jsdossier/CompilerModule.java
@@ -33,8 +33,8 @@ import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
-import com.google.javascript.rhino.jstype.JSTypeRegistry;
 import com.google.javascript.jscomp.parsing.Config;
+import com.google.javascript.rhino.jstype.JSTypeRegistry;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/java/com/github/jsdossier/CompilerModule.java
+++ b/src/java/com/github/jsdossier/CompilerModule.java
@@ -78,7 +78,6 @@ public class CompilerModule extends AbstractModule {
 
     // IDE mode must be enabled or all of the jsdoc info will be stripped from the AST.
     options.setIdeMode(true);
-    options.setPreserveJsDocWhitespace(true);
 
     // For easier debugging.
     options.setPrettyPrint(true);

--- a/src/java/com/github/jsdossier/CompilerModule.java
+++ b/src/java/com/github/jsdossier/CompilerModule.java
@@ -34,6 +34,7 @@ import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.CustomPassExecutionTime;
 import com.google.javascript.rhino.jstype.JSTypeRegistry;
+import com.google.javascript.jscomp.parsing.Config;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -78,6 +79,7 @@ public class CompilerModule extends AbstractModule {
 
     // IDE mode must be enabled or all of the jsdoc info will be stripped from the AST.
     options.setIdeMode(true);
+    options.setParseJsDocDocumentation(Config.JsDocParsing.INCLUDE_DESCRIPTIONS_WITH_WHITESPACE);
 
     // For easier debugging.
     options.setPrettyPrint(true);


### PR DESCRIPTION
`options.setPreserveJsDocWhitespace` is deprecated and removed. As-is, when built with the head compiler, this code throws: `1) Error in custom provider, java.lang.NoSuchMethodError: com.google.javascript.jscomp.CompilerOptions.setPreserveJsDocWhitespace(Z)V`.

The new replacement option `setParseJsDocDocumentation` should be called with `Config.JsDocParsing.INCLUDE_DESCRIPTIONS_WITH_WHITESPACE;`
